### PR TITLE
SHA256 hashing in iMessage class

### DIFF
--- a/src/iMessage.cpp
+++ b/src/iMessage.cpp
@@ -32,7 +32,7 @@ void iMessage::computeHash()
 
 	// Create a string combining timestamp, member_id, and text
 	std::ostringstream data_stream;
-	data_stream << timestamp << "|" << member_id << "|" << text;
+	data_stream << timestamp << member_id << text;
 	std::string data = data_stream.str();
 
 	// Compute hash and copy to hash

--- a/src/iMessage.cpp
+++ b/src/iMessage.cpp
@@ -1,14 +1,41 @@
 #include "iMessage.h"
+#include <openssl/sha.h>
+#include <cstring>
+#include <sstream>
 
-iMessage::iMessage(time_t _timestamp, int _member_id, string _text) : 
+iMessage::iMessage(time_t _timestamp, int _member_id, string _text) :
 	timestamp(_timestamp), member_id(_member_id), text(_text)
-{ }
+{
+	computeHash();
+}
 
-iMessage::iMessage(time_t _timestamp, int _member_id, string _text, vector<std::byte> _hash) : 
+iMessage::iMessage(time_t _timestamp, int _member_id, string _text, std::array<std::byte, 32> _hash) :
 	timestamp(_timestamp), member_id(_member_id), text(_text), hash(_hash)
-{ }
+{
+	computeHash();
+}
+
+iMessage::iMessage(time_t _timestamp, int _member_id, string _text, std::array<std::byte, 32> _hash, std::array<std::byte, 32> _chainHash) :
+	timestamp(_timestamp), member_id(_member_id), text(_text), hash(_hash), chainHash(_chainHash)
+{
+	computeHash();
+}
 
 bool iMessage::hasHash()
 {
 	return !hash.empty();
+}
+
+void iMessage::computeHash()
+{
+	unsigned char hash_buffer[SHA256_DIGEST_LENGTH];
+
+	// Create a string combining timestamp, member_id, and text
+	std::ostringstream data_stream;
+	data_stream << timestamp << "|" << member_id << "|" << text;
+	std::string data = data_stream.str();
+
+	// Compute hash and copy to hash
+	SHA256(reinterpret_cast<const unsigned char*>(data.c_str()), data.size(), hash_buffer);
+	std::memcpy(hash.data(), hash_buffer, SHA256_DIGEST_LENGTH);
 }

--- a/src/iMessage.h
+++ b/src/iMessage.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include <array>
+#include <openssl/sha.h>
 #include "STDimport.h"
 
 /// <summary>
@@ -9,13 +10,17 @@ class iMessage
 {
 public:
 	iMessage(time_t timestamp, int member_id, string text);
-	iMessage(time_t timestamp, int member_id, string text, vector<std::byte> hash);
+	iMessage(time_t timestamp, int member_id, string text, std::array<std::byte, 32> hash);
+	iMessage(time_t timestamp, int member_id, string text, std::array<std::byte, 32> hash, std::array<std::byte, 32> chainHash);
+
 
 	time_t timestamp; // When the message was sent
 	int member_id; // Who sent the message
 	string text; // What was sent
 
-	vector<std::byte> hash;
+	std::array<std::byte, 32> hash;
+	std::array<std::byte, 32> chainHash; //missing implementation
 
 	bool hasHash();
+	void computeHash();
 };

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,1 +1,1 @@
-{"dependencies": ["wxwidgets"]}
+{"dependencies": ["wxwidgets", "openssl"]}


### PR DESCRIPTION
Adding SHA256 hashing to the iMessage class. 

The hash function uses openSSL and creates a hash of the type std::array using the userID, timestamp and message.

Also added chainHash to the iMessage class, but this is still unimplemented.