### PR TITLE
Moved message storage to storage

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -19,15 +19,20 @@ Main::Main() : ThePier(nullptr, wxID_ANY, window_title, wxPoint(30, 30), wxSize(
     }
 
     // ADDED: Ensure chat_history folder exists
-    MessageLogger::EnsureChatHistoryFolder();
+   // MessageLogger::EnsureChatHistoryFolder();
 
     ChannelsBox->SetSelection(storage.currentChannelIndex);
     auto item = ChannelsBox->GetStringSelection();
     ChatLabel->SetLabel(item);
     SendBtn->Enable(false);
 
+    ChatDisplay->Clear();
+    for (auto& m : storage.GetCurrentChannel().messages)
+    {
+        DisplayMsg(m);
+    }
     // ADDED: Load chat history 
-    MessageLogger::LoadChatHistory(ChatDisplay, item);
+   // MessageLogger::LoadChatHistory(ChatDisplay, item);
 }
 
 void Main::OnSendTextChange(wxCommandEvent& event)
@@ -57,7 +62,8 @@ void Main::SendHandler(wxTextCtrl* sendtext) {
     DisplayMsg(m);
 
     // ADDED: Save chat history 
-    MessageLogger::SaveChatHistory(ChatDisplay, ChatLabel->GetLabel());
+    //MessageLogger::SaveChatHistory(ChatDisplay, ChatLabel->GetLabel());
+    storage.AppendMessage(storage.GetCurrentChannel(), m);
 
     sendtext->SetFocus();
 }
@@ -74,7 +80,7 @@ void Main::OnChannelsBox(wxCommandEvent& event) {
     }
 
     // ADDED: Load chat history whenever user switches channels
-    MessageLogger::LoadChatHistory(ChatDisplay, item);
+   // MessageLogger::LoadChatHistory(ChatDisplay, item);
 }
 
 void Main::DisplayMsg(iMessage& m)

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <sstream>
 #include <filesystem>
+#include <iostream>
+#include <fstream>
 
 #include "Storage.h"
 
@@ -30,6 +32,36 @@ static bool read_segment(std::ifstream& file, vector<string>& data)
 	return false;
 }
 
+static string hash_to_string(std::array<std::byte, 32> bytes)
+{
+	char s[65];
+	for (int i = 0; i < 32; i++)
+	{
+		auto byte = (int)(bytes[i]);
+		auto a = (byte & 0xF0) >> 4;
+		auto b = byte & 0x0F;
+		s[i*2] = (char)(a < 10 ? '0' + a : 'a' + a - 10);
+		s[i*2+1] = (char)(b < 10 ? '0' + b : 'a' + b - 10);
+	}
+	s[64] = 0;
+	return s;
+}
+
+static std::array<std::byte, 32> string_to_hash(string hexidecimal)
+{
+	std::array<std::byte, 32> out{};
+	
+	auto in = hexidecimal.c_str();
+	for (int i = 0; i < 32; i++)
+	{
+		auto a = in[i * 2] < 'a' ? in[i * 2] - '0' : in[i * 2] - 'a' + 10;
+		auto b = in[i * 2 + 1] < 'a' ? in[i * 2 + 1] - '0' : in[i * 2 + 1] - 'a' + 10;
+		auto c = a << 4 | b;
+		out[i] = (std::byte)(c);
+	}
+	return out;
+}
+
 void Storage::OpenStorage(string filename)
 {
 	//std::filesystem::path cwd = std::filesystem::current_path() / filename;
@@ -41,6 +73,46 @@ void Storage::OpenStorage(string filename)
 	{
 		channels.push_back({data[0], data[1] == "true"});
 	}
+
+	for (auto& ch : channels)
+	{
+		string filePath = "chat_history/" + ch.name + "messagedata.txt";
+		std::ifstream file(filePath);
+
+		if (!file) return;
+
+		while (read_segment(file, data) && data.size() > 1)
+		{
+			auto a = std::stoi(data[0]);
+			ch.messages.push_back(iMessage(std::stoi(data[0]), std::stoi(data[1]), data[2], string_to_hash(data[3])));
+		}
+	}
+}
+
+void Storage::AppendMessage(Channel c, iMessage msg)
+{
+	string filePath = "chat_history/" + c.name + "messagedata.txt";
+
+	// 1) Read existing file content
+	std::fstream inFile(filePath, std::fstream::out | std::fstream::app | std::fstream::ate);
+	if (!inFile.is_open() && !inFile.good())
+	{
+		// If no file yet, we can just write everything
+		std::ofstream createFile(filePath, std::ios::out | std::ios::trunc);
+		if (!createFile)
+		{
+			//wxMessageBox("Failed to create chat history file", "Error");
+			return;
+		}
+		createFile << msg.timestamp << ";" << std::to_string(msg.member_id) << ";" << msg.text << ";" << hash_to_string(msg.hash) << std::endl ;
+
+		createFile.close();
+		return;
+	}
+
+	inFile << msg.timestamp << ";" << std::to_string(msg.member_id) << ";" << msg.text << ";" << hash_to_string(msg.hash) << std::endl ;
+	inFile.close();
+	return;
 }
 
 Channel& Storage::GetCurrentChannel()

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -16,6 +16,8 @@ public:
 
 	void OpenStorage(string filename);
 
+	void AppendMessage(Channel c, iMessage msg);
+
 	vector<Channel> channels; // channels i am part of
 	vector<User> users; // users i know, which means they are a member of a channel i am a part of
 

--- a/src/chat_history/Bulliesmessagedata.txt
+++ b/src/chat_history/Bulliesmessagedata.txt
@@ -1,2 +1,0 @@
-20:17 TestBullie: ..¨
-09:04 TestBullie: appppppppppppppppppppppppppppppppppp

--- a/src/chat_history/Ninjasmessagedata.txt
+++ b/src/chat_history/Ninjasmessagedata.txt
@@ -1,4 +1,1 @@
-21:04 TestNinja: work pls
-09:04 TestNinja: Nuh uh ¨
-09:17 TestNinja: hello
-09:35 TestNinja: hello
+1742980358;0;7772772;583beed70fdbd922e7c6b1565b50eb9913b8a37ce4fec4b37b27660397bece1d

--- a/src/chat_history/Piratesmessagedata.txt
+++ b/src/chat_history/Piratesmessagedata.txt
@@ -1,1 +1,0 @@
-20:17 TestPirate: ..


### PR DESCRIPTION
### Changes

- Added support method hash_to_string.
- Added support method string_to_hash.
- Extendde OpenStorage to read messages from /chathistory/. 
- Added storage::AppendMessage which pushes a message from a channel into that channels storage file on disc.

### Storage
Moved message storage to use the storage class. Allowing for opening messages in the iMessage format with timestamp etc for programmatic handling of those values in other areas of the application.

### Hash
Added methods for converting a sha256 hash to a string of hexidecimals. Which is easier to verify correctness of by humans.