### PR TITLE
Implement asynchronous networking via. Boost.asio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /vcpkg_installed
+/.vscode

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -48,6 +48,11 @@ void Main::SendHandler(wxTextCtrl* sendtext)
 	sendtext->SetFocus();
 }
 
+Storage& Main::GetStorage()
+{
+	return storage;
+}
+
 void Main::OnChannelsBox(wxCommandEvent& event)
 {
 	auto item = ChannelsBox->GetStringSelection();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -99,3 +99,10 @@ bool Main::Login(User user, std::string password)
 	this->currentPassword = password;
 	return true; // if storage can be opened 
 }
+
+void Main::ReceiveHandler(Channel *ch, iMessage msg)
+{
+	storage.AppendMessage(*ch, msg);
+	if (ch->channel_id != storage.GetCurrentChannel().channel_id) return;
+	DisplayMsg(msg);
+}

--- a/src/Main.h
+++ b/src/Main.h
@@ -6,6 +6,7 @@
 #include "LoginController.h"
 #include "Channel.h"
 #include "MainLoginInterface.h"
+#include "Storage.h"
 
 using std::to_string;
 
@@ -19,6 +20,7 @@ public:
 
 	Main();
 
+	static Storage& GetStorage();
 	void OnChannelsBox(wxCommandEvent& event);
 
 	void DisplayMsg(iMessage& m);

--- a/src/Main.h
+++ b/src/Main.h
@@ -6,11 +6,12 @@
 #include "LoginController.h"
 #include "Channel.h"
 #include "MainLoginInterface.h"
+#include "MainReceiveMessageInterface.h"
 #include "Storage.h"
 
 using std::to_string;
 
-class Main : public ThePier, public MainLoginInterface
+class Main : public ThePier, public MainLoginInterface, public MainReceiveMessageInterface
 {
 	wxString window_title = "The Pier";
 
@@ -20,7 +21,7 @@ public:
 
 	Main();
 
-	static Storage& GetStorage();
+	Storage& GetStorage();
 	void OnChannelsBox(wxCommandEvent& event);
 
 	void DisplayMsg(iMessage& m);
@@ -32,6 +33,8 @@ public:
 	void SendHandler(wxTextCtrl* sendtext);
 
 	bool Login(User user, string password);
+
+	void ReceiveHandler(Channel *ch, iMessage msg);
 
 	void DoLogin();
 	void ClickCreateNewUser(wxCommandEvent& event);

--- a/src/MainReceiveMessageInterface.h
+++ b/src/MainReceiveMessageInterface.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "Channel.h"
+#include "iMessage.h"
+
+#include "Storage.h"
+class MainReceiveMessageInterface
+{
+public:
+	virtual void ReceiveHandler(Channel *ch, iMessage msg) = 0;
+	virtual Storage& GetStorage() = 0;
+};

--- a/src/PierClient.cpp
+++ b/src/PierClient.cpp
@@ -75,6 +75,23 @@ void PierClient::do_write(const_buffer data)
 			{
 				// Handle error. Maybe try send again.
 			}
+			else
+			{
+				// Receive possible answer from server.
+
+				/*
+				if (expecting_answer)
+				*/
+				{
+					sock.async_receive(buffer(recvbuf), std::bind(&PierClient::handle_read, this, placeholders::error, placeholders::bytes_transferred));
+				}
+
+			}
 		}
 	);
+}
+
+void PierClient::handle_read(const boost::system::error_code& err, size_t bytes_read)
+{
+
 }

--- a/src/PierClient.cpp
+++ b/src/PierClient.cpp
@@ -14,6 +14,7 @@ void PierClient::write(const_buffer data)
 	// We sleep the thread and try again if not connected.
 	if (!connected)
 	{
+		// Probably needs other retry-solution. This could pause the program for a pretty long time.
 		std::this_thread::sleep_for(std::chrono::milliseconds(500));
 		write(data);
 		return;

--- a/src/PierClient.cpp
+++ b/src/PierClient.cpp
@@ -95,7 +95,7 @@ void PierClient::do_write(const_buffer header, const_buffer data)
 
 void PierClient::handle_read(const boost::system::error_code& err, size_t bytes_read)
 {
-
+	// Switch-case with different options for returns from peer.
 }
 
 void PierClient::handle_data_send(const boost::system::error_code err, size_t bytes_sent)
@@ -110,7 +110,7 @@ void PierClient::handle_data_send(const boost::system::error_code err, size_t by
 		
 		if (false) // TEMPORARY
 		{
-			sock.async_receive(buffer(recvbuf), std::bind(&PierClient::handle_read, this, placeholders::error, placeholders::bytes_transferred));
+			async_read(sock, buffer(recvbuf), std::bind(&PierClient::handle_read, this, placeholders::error, placeholders::bytes_transferred));
 		}
 	}
 }

--- a/src/PierClient.cpp
+++ b/src/PierClient.cpp
@@ -1,0 +1,58 @@
+#include "PierClient.h"
+
+using namespace boost::asio;
+using boost::asio::ip::tcp;
+using boost::asio::io_context;
+
+PierClient::PierClient(io_context& io, tcp::endpoint endpoint) : io_(io), sock(io)
+{
+	do_connect(endpoint);
+}
+
+void PierClient::write(const_buffer data)
+{
+	if (!connected)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(500));
+		write(data);
+		return;
+	}
+	do_write(data);
+
+}
+
+void PierClient::close()
+{
+	sock.close();
+}
+
+void PierClient::do_connect(const tcp::endpoint endpoint)
+{
+	sock.async_connect(endpoint,
+		[this, endpoint](boost::system::error_code err)
+		{
+			// Try again if connect fails. Probably a bit scary to do this infinitely...
+			if (err)
+			{
+				do_connect(endpoint);
+			}
+			else
+			{
+				connected = true;
+			}
+		}
+	);
+}
+
+void PierClient::do_write(const_buffer data)
+{
+	sock.async_write_some(data, 
+		[this](boost::system::error_code err, size_t bytes_sent) 
+		{
+			if (err)
+			{
+				// Handle error. Maybe try send again.
+			}
+		}
+	);
+}

--- a/src/PierClient.h
+++ b/src/PierClient.h
@@ -11,16 +11,17 @@ public:
 	PierClient(io_context& io, tcp::endpoint endpoint);
 
 	// Write a buffer to the connected endpoint.
-	void write(boost::asio::const_buffer data);
+	void write(boost::asio::const_buffer header, boost::asio::const_buffer data);
 
 	// Close the client.
 	void close();
 
-	static void write_several_peers(std::vector<tcp::endpoint> endpoints, boost::asio::const_buffer data);
+	static void write_several_peers(std::vector<tcp::endpoint> endpoints, boost::asio::const_buffer header, boost::asio::const_buffer data);
 private:
 	void do_connect(const tcp::endpoint endpoint);
-	void do_write(boost::asio::const_buffer data);
+	void do_write(boost::asio::const_buffer header, boost::asio::const_buffer data);
 	void handle_read(const boost::system::error_code& err, size_t bytes_read);
+	void handle_data_send(const boost::system::error_code err, size_t bytes_sent);
 
 	bool connected = false;
 	tcp::socket sock;

--- a/src/PierClient.h
+++ b/src/PierClient.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <boost/asio.hpp>
+
+using namespace boost::asio;
+using boost::asio::ip::tcp;
+using boost::asio::io_context;
+
+class PierClient
+{
+public:
+	PierClient(io_context& io, tcp::endpoint endpoint);
+
+	void write(const_buffer data);
+	void close();
+
+private:
+	void do_connect(const tcp::endpoint endpoint);
+	void do_write(const_buffer data);
+	
+	bool connected = false;
+	tcp::socket sock;
+	io_context& io_;
+	std::array<char, 1024> recvbuf;
+};

--- a/src/PierClient.h
+++ b/src/PierClient.h
@@ -2,7 +2,6 @@
 #include <boost/asio.hpp>
 #include <vector>
 
-using namespace boost::asio;
 using boost::asio::ip::tcp;
 using boost::asio::io_context;
 
@@ -12,15 +11,15 @@ public:
 	PierClient(io_context& io, tcp::endpoint endpoint);
 
 	// Write a buffer to the connected endpoint.
-	void write(const_buffer data);
+	void write(boost::asio::const_buffer data);
 
 	// Close the client.
 	void close();
 
-	static void write_several_peers(std::vector<tcp::endpoint> endpoints, const_buffer data);
+	static void write_several_peers(std::vector<tcp::endpoint> endpoints, boost::asio::const_buffer data);
 private:
 	void do_connect(const tcp::endpoint endpoint);
-	void do_write(const_buffer data);
+	void do_write(boost::asio::const_buffer data);
 	
 	bool connected = false;
 	tcp::socket sock;

--- a/src/PierClient.h
+++ b/src/PierClient.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <boost/asio.hpp>
+#include <vector>
 
 using namespace boost::asio;
 using boost::asio::ip::tcp;
@@ -10,9 +11,13 @@ class PierClient
 public:
 	PierClient(io_context& io, tcp::endpoint endpoint);
 
+	// Write a buffer to the connected endpoint.
 	void write(const_buffer data);
+
+	// Close the client.
 	void close();
 
+	static void write_several_peers(std::vector<tcp::endpoint> endpoints, const_buffer data);
 private:
 	void do_connect(const tcp::endpoint endpoint);
 	void do_write(const_buffer data);

--- a/src/PierClient.h
+++ b/src/PierClient.h
@@ -20,7 +20,8 @@ public:
 private:
 	void do_connect(const tcp::endpoint endpoint);
 	void do_write(boost::asio::const_buffer data);
-	
+	void handle_read(const boost::system::error_code& err, size_t bytes_read);
+
 	bool connected = false;
 	tcp::socket sock;
 	io_context& io_;

--- a/src/PierListener.cpp
+++ b/src/PierListener.cpp
@@ -1,0 +1,51 @@
+#include "PierListener.h"
+
+using namespace boost::asio;
+using boost::asio::ip::tcp;
+using boost::asio::io_context;
+
+void tcp_connection::start_receive()
+{
+	sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_first_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
+}
+
+void tcp_connection::start_write(const_buffer data)
+{
+}
+
+
+// TODO: Get the read data out.
+void tcp_connection::handle_first_read(const boost::system::error_code& err, size_t bytes_read)
+{
+	if (!err)
+	{
+		// Decode header. 
+		// Keep receiving.
+		sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
+	}
+	else
+	{
+		sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_first_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));	
+	}
+}
+
+void tcp_connection::handle_read(const boost::system::error_code& err, size_t bytes_read)
+{
+	if (!err)
+	{
+		// Apend buffer to string or something like that.
+	}
+
+	// Keep receiving. 
+	sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
+}
+
+void tcp_connection::handle_write(const boost::system::error_code& err, size_t bytes_sent)
+{
+	// Probably not good error handling.
+	if (err)
+	{
+		// Close socket if a write-error occurs.
+		sock.close();
+	}
+}

--- a/src/PierListener.cpp
+++ b/src/PierListener.cpp
@@ -14,7 +14,6 @@ void tcp_connection::start_write(const_buffer data)
 	sock.async_send(data, std::bind(&tcp_connection::handle_write, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
 }
 
-
 // TODO: Get the read data out.
 void tcp_connection::handle_first_read(const boost::system::error_code& err, size_t bytes_read)
 {

--- a/src/PierListener.cpp
+++ b/src/PierListener.cpp
@@ -58,12 +58,12 @@ void tcp_connection::handle_first_read(const boost::system::error_code& err, siz
 
 		// Decode header. 
 		// Keep receiving.
-		sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
+		//sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
 	}
 	else
 	{
 		// Should maybe just close socket here.
-		sock.async_receive(buffer(recvbuf), std::bind(&tcp_connection::handle_first_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));	
+		async_read(sock, buffer(recvbuf), transfer_exactly(sizeof(PierProtocol::PierHeader)), std::bind(&tcp_connection::handle_first_read, shared_from_this(), placeholders::error, placeholders::bytes_transferred));
 	}
 }
 

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -2,7 +2,6 @@
 #include <boost/asio.hpp>
 #include <memory>
 
-using namespace boost::asio;
 using boost::asio::ip::tcp;
 using boost::asio::io_context;
 
@@ -22,7 +21,7 @@ public:
 	void start_receive();
 
 	// Write data over the connection. The const_buffer must be valid while the write completes asynchronously.
-	void start_write(const_buffer data);
+	void start_write(boost::asio::const_buffer data);
 
 private:
 	tcp_connection(io_context& io) : io_(io), sock(io) {};

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -2,11 +2,12 @@
 #include "MainReceiveMessageInterface.h"
 #include <boost/asio.hpp>
 #include <memory>
+#include "Channel.h"
 
 using boost::asio::ip::tcp;
 using boost::asio::io_context;
 
-class tcp_connection : std::enable_shared_from_this<tcp_connection>
+class tcp_connection : public std::enable_shared_from_this<tcp_connection>
 {
 
 public:
@@ -36,7 +37,7 @@ private:
 	// Handler function called after write.
 	void handle_write(const boost::system::error_code& err, size_t bytes_sent);
 	
-	void read_msg_handler(const boost::system::error_code& err, size_t bytes_read);
+	void read_msg_handler(const boost::system::error_code& err, size_t bytes_read, Channel *ch);
 	
 	Channel *channel;
 	MainReceiveMessageInterface* mn = nullptr;

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <boost/asio.hpp>
+#include <memory>
+
+using namespace boost::asio;
+using boost::asio::ip::tcp;
+using boost::asio::io_context;
+
+class tcp_connection : std::enable_shared_from_this<tcp_connection>
+{
+
+	
+public:
+	typedef std::shared_ptr<tcp_connection> ptr;
+
+	// Create a smart-pointer to a new connection object.
+	static ptr create(io_context& io) { return ptr(new tcp_connection(io)); };
+	
+	// Get the socket the connection is on.
+	tcp::socket& get_socket() { return sock; };
+
+	// Start receiving data over the connection.
+	void start_receive();
+
+	// Write data over the connection. The const_buffer must be valid while the write completes asynchronously.
+	void start_write(const_buffer data);
+
+private:
+	tcp_connection(io_context& io) : io_(io), sock(io) {};
+
+	// Handler function called after first read operation.
+	void handle_first_read(const boost::system::error_code& err, size_t bytes_read);
+
+	// Handler function called after subsequent reads.
+	void handle_read(const boost::system::error_code& err, size_t bytes_read);
+	
+	// Handler function called after write.
+	void handle_write(const boost::system::error_code& err, size_t bytes_sent);
+	
+	tcp::socket sock;
+	io_context& io_;
+	std::array<char, 1024> recvbuf {0};
+
+};
+
+class PierListener
+{
+};
+

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -35,6 +35,9 @@ private:
 	// Handler function called after write.
 	void handle_write(const boost::system::error_code& err, size_t bytes_sent);
 	
+	void read_msg_handler(boost::asio::streambuf& buf, const boost::system::error_code& err, size_t bytes_read);
+
+	boost::asio::streambuf read_buf;
 	tcp::socket sock;
 	io_context& io_;
 	std::array<char, 1024> recvbuf {0};

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -2,8 +2,6 @@
 #include <boost/asio.hpp>
 #include <memory>
 
-
-
 using namespace boost::asio;
 using boost::asio::ip::tcp;
 using boost::asio::io_context;
@@ -11,7 +9,6 @@ using boost::asio::io_context;
 class tcp_connection : std::enable_shared_from_this<tcp_connection>
 {
 
-	
 public:
 	typedef std::shared_ptr<tcp_connection> ptr;
 

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -2,6 +2,8 @@
 #include <boost/asio.hpp>
 #include <memory>
 
+
+
 using namespace boost::asio;
 using boost::asio::ip::tcp;
 using boost::asio::io_context;
@@ -45,5 +47,18 @@ private:
 
 class PierListener
 {
+public:
+	PierListener(io_context& io);
+	static constexpr int default_listening_port = 10000;
+
+private:
+	// Start accepting connections.
+	void start_accept();
+
+	// Handler function called after accept.
+	void handle_accept(tcp_connection::ptr new_conn, const boost::system::error_code& err);
+
+	io_context& io_;
+	tcp::acceptor acceptor;
 };
 

--- a/src/PierListener.h
+++ b/src/PierListener.h
@@ -35,8 +35,8 @@ private:
 	// Handler function called after write.
 	void handle_write(const boost::system::error_code& err, size_t bytes_sent);
 	
-	void read_msg_handler(boost::asio::streambuf& buf, const boost::system::error_code& err, size_t bytes_read);
-
+	void read_msg_handler(const boost::system::error_code& err, size_t bytes_read);
+	boost::asio::streambuf msg_buf;
 	boost::asio::streambuf read_buf;
 	tcp::socket sock;
 	io_context& io_;

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -59,8 +59,6 @@ void PierProtocol::SendMSG(Channel ch, iMessage msg)
 
     std::string send;
 
-    std::array<char, sizeof(time_t) + 1> t_arr{};
-
     // Append timestamp;
     send.append(reinterpret_cast<const char*>(&(msg.timestamp)), sizeof(iMessage::timestamp));
     

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -1,0 +1,41 @@
+#include "Protocol.h"
+#include "cstring"
+
+std::array<char, 40> PierProtocol::encode_header(PierHeader header)
+{
+    std::array<char, 40> out{0};
+    memcpy(out.data(), &(header.type), sizeof(SendType));
+    memcpy(out.data() + sizeof(SendType), &(header.sender_GUID), sizeof(GUID));
+    memcpy(out.data() + sizeof(SendType) + sizeof(GUID), &(header.channel_GUID), sizeof(GUID));
+    memcpy(out.data() + 2 * sizeof(GUID) + sizeof(SendType), &(header.size), sizeof(uint32_t));
+    
+    return out;
+}
+
+PierProtocol::PierHeader PierProtocol::decode_header(boost::asio::const_buffer header)
+{
+    char *buf = (char *)header.data();
+
+    SendType type;
+    GUID sender;
+    GUID channel;
+    uint32_t size;
+
+    memcpy(buf, &type, sizeof(SendType));
+    buf += sizeof(SendType);
+    memcpy(buf, &sender, sizeof(GUID));
+    buf += sizeof(GUID);
+    memcpy(buf, &channel, sizeof(GUID));
+    buf += sizeof(GUID);
+    memcpy(buf, &size, sizeof(uint32_t));
+
+    PierHeader out 
+    {
+        .type = type,
+        .sender_GUID = sender,
+        .channel_GUID = channel,
+        .size = size
+    };
+    
+    return out;
+}

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -45,10 +45,10 @@ PierProtocol::PierHeader PierProtocol::decode_header(boost::asio::const_buffer h
     return out;
 }
 
-void PierProtocol::SendMSG(Channel ch, iMessage msg, User sender)
+void PierProtocol::SendMSG(Channel ch, iMessage msg, User sender, Storage &storage)
 {
     std::vector<boost::asio::ip::tcp::endpoint> endpoints;
-    
+
     PierHeader header
     {
         .type = MESSAGE,
@@ -77,8 +77,6 @@ void PierProtocol::SendMSG(Channel ch, iMessage msg, User sender)
     header.size = send.length();
     std::array<char, 40> header_arr = encode_header(header);
     boost::asio::const_buffer header_buf = boost::asio::buffer(header_arr);
-
-    Storage storage; // = Main::GetStorage();
 
     for (auto& mem : ch.members)
     {

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include "PierClient.h"
 #include <ctime>
-#include "Main.h"
+#include "MainReceiveMessageInterface.h"
 
 
 std::array<char, 40> PierProtocol::encode_header(PierHeader header)
@@ -78,7 +78,7 @@ void PierProtocol::SendMSG(Channel ch, iMessage msg, User sender)
     std::array<char, 40> header_arr = encode_header(header);
     boost::asio::const_buffer header_buf = boost::asio::buffer(header_arr);
 
-    Storage storage = Main::GetStorage();
+    Storage storage; // = Main::GetStorage();
 
     for (auto& mem : ch.members)
     {

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -3,6 +3,9 @@
 #include "Channel.h"
 #include "iMessage.h"
 #include "Storage.h"
+#include "PierListener.h"
+#include "MainReceiveMessageInterface.h"
+
 
 #include <boost/asio.hpp>
 
@@ -34,6 +37,14 @@ struct PierHeader
 
 std::array<char, 40> encode_header(PierHeader header);
 PierHeader decode_header(boost::asio::const_buffer header);
+
+class ProtocolHandler
+{
+    
+private:
+    PierListener lstn;
+    MainReceiveMessageInterface* mn;
+};
 
 void SendMSG(Channel ch, iMessage msg, User sender);
 void SendMSGRequest(Channel ch, Member memb, iMessage::shash hash, User sender);

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -46,7 +46,7 @@ private:
     MainReceiveMessageInterface* mn;
 };
 
-void SendMSG(Channel ch, iMessage msg, User sender);
+void SendMSG(Channel ch, iMessage msg, User sender, Storage &storage);
 void SendMSGRequest(Channel ch, Member memb, iMessage::shash hash, User sender);
 void SendMSGMulti(Channel ch, Member memb, std::vector<iMessage> msgs, User sender);
 void SendSyncProbe(Channel ch, iMessage::shash hash, User sender);

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -1,5 +1,9 @@
 #pragma once
 #include <memory>
+#include "Channel.h"
+#include "iMessage.h"
+#include "Storage.h"
+
 #include <boost/asio.hpp>
 
 namespace PierProtocol
@@ -28,8 +32,17 @@ struct PierHeader
     uint32_t size;
 };
 
+static Storage storage;
+
 std::array<char, 40> encode_header(PierHeader header);
 PierHeader decode_header(boost::asio::const_buffer header);
 
+void SendMSG(Channel ch, iMessage msg);
+void SendMSGRequest(Channel ch, Member memb, iMessage::shash hash);
+void SendMSGMulti(Channel ch, Member memb, std::vector<iMessage> msgs);
+void SendSyncProbe(Channel ch, iMessage::shash hash);
+void SendSyncStatus(Channel ch, Member memb, uint8_t flag);
+void SendSHASHRequest(Channel ch, Member memb, uint32_t amount);
+void SendSHASHMulti(Channel ch, Member memb, std::vector<iMessage::shash> hashes);
 
 }

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -32,8 +32,6 @@ struct PierHeader
     uint32_t size;
 };
 
-static Storage storage;
-
 std::array<char, 40> encode_header(PierHeader header);
 PierHeader decode_header(boost::asio::const_buffer header);
 

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -35,12 +35,12 @@ struct PierHeader
 std::array<char, 40> encode_header(PierHeader header);
 PierHeader decode_header(boost::asio::const_buffer header);
 
-void SendMSG(Channel ch, iMessage msg);
-void SendMSGRequest(Channel ch, Member memb, iMessage::shash hash);
-void SendMSGMulti(Channel ch, Member memb, std::vector<iMessage> msgs);
-void SendSyncProbe(Channel ch, iMessage::shash hash);
-void SendSyncStatus(Channel ch, Member memb, uint8_t flag);
-void SendSHASHRequest(Channel ch, Member memb, uint32_t amount);
-void SendSHASHMulti(Channel ch, Member memb, std::vector<iMessage::shash> hashes);
+void SendMSG(Channel ch, iMessage msg, User sender);
+void SendMSGRequest(Channel ch, Member memb, iMessage::shash hash, User sender);
+void SendMSGMulti(Channel ch, Member memb, std::vector<iMessage> msgs, User sender);
+void SendSyncProbe(Channel ch, iMessage::shash hash, User sender);
+void SendSyncStatus(Channel ch, Member memb, uint8_t flag, User sender);
+void SendSHASHRequest(Channel ch, Member memb, uint32_t amount, User sender);
+void SendSHASHMulti(Channel ch, Member memb, std::vector<iMessage::shash> hashes, User sender);
 
 }

--- a/src/Protocol.h
+++ b/src/Protocol.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <memory>
+#include <boost/asio.hpp>
+
+namespace PierProtocol
+{
+
+enum SendType
+{
+    JOIN = 0,
+    INVITE,
+    MESSAGE,
+    MESSAGE_REQUEST,
+    MESSAGE_MULTI,
+    SYNC_PROBE,
+    SYNC_STATUS,
+    SHASH_REQUEST,
+    SHASH_MULTI,
+    CHANGEIP,
+    SENDTYPE_END
+};
+
+struct PierHeader
+{
+    SendType type;
+    GUID sender_GUID;
+    GUID channel_GUID;
+    uint32_t size;
+};
+
+std::array<char, 40> encode_header(PierHeader header);
+PierHeader decode_header(boost::asio::const_buffer header);
+
+
+}

--- a/src/ThePier.vcxproj
+++ b/src/ThePier.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="Member.cpp" />
     <ClCompile Include="PierClient.cpp" />
     <ClCompile Include="PierListener.cpp" />
+    <ClCompile Include="Protocol.cpp" />
     <ClCompile Include="sync.cpp" />
     <ClCompile Include="Storage.cpp" />
     <ClCompile Include="ThePierGUI.cpp" />
@@ -205,6 +206,7 @@
     <ClInclude Include="Member.h" />
     <ClInclude Include="PierClient.h" />
     <ClInclude Include="PierListener.h" />
+    <ClInclude Include="Protocol.h" />
     <ClInclude Include="STDimport.h" />
     <ClInclude Include="Storage.h" />
     <ClInclude Include="ThePierGUI.h" />

--- a/src/ThePier.vcxproj
+++ b/src/ThePier.vcxproj
@@ -203,6 +203,7 @@
     <ClInclude Include="LoginController.h" />
     <ClInclude Include="Main.h" />
     <ClInclude Include="MainLoginInterface.h" />
+    <ClInclude Include="MainReceiveMessageInterface.h" />
     <ClInclude Include="Member.h" />
     <ClInclude Include="PierClient.h" />
     <ClInclude Include="PierListener.h" />

--- a/src/ThePier.vcxproj
+++ b/src/ThePier.vcxproj
@@ -187,6 +187,7 @@
     <ClCompile Include="MainLogin.cpp" />
     <ClCompile Include="MainTest.cpp" />
     <ClCompile Include="Member.cpp" />
+    <ClCompile Include="PierListener.cpp" />
     <ClCompile Include="sync.cpp" />
     <ClCompile Include="Storage.cpp" />
     <ClCompile Include="ThePierGUI.cpp" />
@@ -201,6 +202,7 @@
     <ClInclude Include="Main.h" />
     <ClInclude Include="MainLoginInterface.h" />
     <ClInclude Include="Member.h" />
+    <ClInclude Include="PierListener.h" />
     <ClInclude Include="STDimport.h" />
     <ClInclude Include="Storage.h" />
     <ClInclude Include="ThePierGUI.h" />

--- a/src/ThePier.vcxproj
+++ b/src/ThePier.vcxproj
@@ -187,6 +187,7 @@
     <ClCompile Include="MainLogin.cpp" />
     <ClCompile Include="MainTest.cpp" />
     <ClCompile Include="Member.cpp" />
+    <ClCompile Include="PierClient.cpp" />
     <ClCompile Include="PierListener.cpp" />
     <ClCompile Include="sync.cpp" />
     <ClCompile Include="Storage.cpp" />
@@ -202,6 +203,7 @@
     <ClInclude Include="Main.h" />
     <ClInclude Include="MainLoginInterface.h" />
     <ClInclude Include="Member.h" />
+    <ClInclude Include="PierClient.h" />
     <ClInclude Include="PierListener.h" />
     <ClInclude Include="STDimport.h" />
     <ClInclude Include="Storage.h" />

--- a/src/ThePier.vcxproj.filters
+++ b/src/ThePier.vcxproj.filters
@@ -23,6 +23,9 @@
     <ClCompile Include="sync.cpp" />
     <ClCompile Include="LoginController.cpp" />
     <ClCompile Include="MainLogin.cpp" />
+    <ClCompile Include="PierClient.cpp" />
+    <ClCompile Include="PierListener.cpp" />
+    <ClCompile Include="Protocol.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ThePierGUI.h">
@@ -37,6 +40,9 @@
     <ClInclude Include="STDimport.h" />
     <ClInclude Include="User.h" />
     <ClInclude Include="LoginController.h" />
+    <ClInclude Include="PierClient.h" />
+    <ClInclude Include="PierListener.h" />
+    <ClInclude Include="Protocol.h" />
     <ClInclude Include="MainLoginInterface.h" />
   </ItemGroup>
   <ItemGroup>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,1 +1,7 @@
-{"dependencies": ["wxwidgets", "openssl"]}
+{
+  "dependencies": [
+    "openssl",
+    "wxwidgets",
+    "boost-asio"
+  ]
+}


### PR DESCRIPTION
# Added items
## .cpp & .h files
- PierClient
- PierListener
- Protocol
## Classes and namespaces
- class `tcp_connection`
- class `PierListener`
- class `PierClient`
- namespace `PierProtocol`

# How it works
## PierListener & tcp_connection
A `PierListener` object is created. This listens for incoming connections on a port (this is by default set to 10000). When an incoming connection is accepted, a `tcp_connection` is created, the `tcp_connection` tries to read a `PierProtocol::PierHeader` over this. If this succeds, the handling of different scenarios can then proceed (currently only receiving a message partially implemented). 

## PierClient
To connect to a `PierListener`, create a `PierClient` object. The constructor `PierClient()`, takes a `boost::asio::ip::tcp::endpoint` as a paremeter, and attempts to connect to the default port 10000. 
To write data to the `PierListener`, call the member function `PierClient::write()`. This takes two parameters - both `boost::asio::const_buffer`. These are `header` and `data`. When called, write attempts to write these two in succession.

# PierProtocol
## SendMSG
**Parameters:**
1. `Channel ch`
2. `iMessage msg`

**Description:**
`PierProtocol::SendMSG` takes a `Channel` and an `iMessage` and uses `PierClient::write_several_peers` to send it to all members in the channel. 
